### PR TITLE
Custom posts losing settings

### DIFF
--- a/includes/wp-geo.php
+++ b/includes/wp-geo.php
@@ -1172,6 +1172,13 @@ class WPGeo {
 			$wp_geo_options['show_maps_on_excerpts']         = isset( $_POST['show_maps_on_excerpts'] ) && $_POST['show_maps_on_excerpts'] == 'Y' ? 'Y' : 'N';
 			$wp_geo_options['show_maps_on_customposttypes']  = array();
 			
+			// Ensure post types that support WP Geo continue to do so.  disabled checkboxes aren't being submitted.
+			$post_types = get_post_types( array(), 'objects' );
+			foreach ( $post_types as $post_type ) {
+				if ( $post_type->name != 'post' && $post_type->name != 'page' && post_type_supports( $post_type->query_var, 'wpgeo' ) ) {
+					$wp_geo_options['show_maps_on_customposttypes'][$post_type->name] = 'Y';
+				}
+			}
 			if ( isset( $_POST['show_maps_on_customposttypes'] ) && is_array( $_POST['show_maps_on_customposttypes'] ) ) {
 				foreach ( $_POST['show_maps_on_customposttypes'] as $key => $val ) {
 					$wp_geo_options['show_maps_on_customposttypes'][$key] = $val == 'Y' ? 'Y' : 'N';


### PR DESCRIPTION
Hi Ben,

Firstly, thanks for a great plugin.  I appreciate you making it available, and hope you find this change useful.

Secondly, apologies if the content of this message should be somewhere else (eg in the commit message) - I'm new to github.

I had an issue with custom posts.  After enabling WP Geo for a custom post, the setting is lost when the settings screen is re-submitted.  The checkbox cycles through selected, disabled (but checked), and finally deselected (a couple of times each).

To reproduce, just create a simple custom post type.  I used:

<pre>
    add_action( 'init', 'create_post_type' );
    function create_post_type() {
        register_post_type( 'acme_product',
            array(
                'labels' => array(
                    'name' => __( 'Products' ),
                    'singular_name' => __( 'Product' )
                ),
            'public' => true,
            'has_archive' => true,
            )
        );
    }
</pre>


Select the post type in the settings screen, and click "Save changes" a few times to see the cycle.

It seems to come down to disabled checkbox values not being submitted with the form.  Not sure if that's specific to Chrome, but that's what I use, so it was an issue for me.

I tried the fix mentioned [here](http://wordpress.org/support/topic/wp-geo-in-custom-post-types), but that didn't work as I'd hoped; the checkbox remains checked in the admin screen, but the post doesn't show the map, as the setting isn't persisted.

I don't understand the rationale for disabling the checkbox, so I didn't want to blindly enable it.  I went with the minimum change I could see that would address the issue.

Thanks again for the plugin.  Hope this helps you.

Pete
