### PR TITLE
Fix some JS errors

### DIFF
--- a/api/googlemapsv3/js/admin-post.js
+++ b/api/googlemapsv3/js/admin-post.js
@@ -1,35 +1,35 @@
 
 (function($){
-	
+
 	/**
 	 * Google API v3
 	 */
 	function wpgeo_init_admin_post_map() {
-		
+
 		$(document).ready(function($) {
-			
+
 			// Define map
 			WPGeo_Admin.map = new google.maps.Map(document.getElementById(WPGeo_Admin.map_dom_id), {
-				zoom           : WPGeo_Admin.zoom,
+				zoom           : parseInt(WPGeo_Admin.zoom, 10),
 				center         : new google.maps.LatLng(WPGeo_Admin.mapCentreX, WPGeo_Admin.mapCentreY),
 				mapTypeId      : WPGeo_Admin.mapType,
 				zoomControl    : true,
 				mapTypeControl : true
 			});
-			
+
 			// Define marker
 			WPGeo_Admin.marker = new google.maps.Marker({
 				position  : new google.maps.LatLng(WPGeo_Admin.latitude, WPGeo_Admin.longitude),
 				map       : WPGeo_Admin.map,
 				draggable : true
 			});
-			
+
 			// Update marker location
 			$("#wpgeo_location").bind("WPGeo_updateMarkerLatLng", function(e) {
 				WPGeo_Admin.marker.setPosition(e.latLng);
 				WPGeo_Admin.marker.setVisible(true);
 			});
-			
+
 			// Update location field
 			$("#wpgeo_location").bind("WPGeo_updateLatLngField", function(e) {
 				if ( e.lat == '' || e.lng == '' ) {
@@ -47,7 +47,7 @@
 					});
 				}
 			});
-			
+
 			// Click on map
 			google.maps.event.addListener(WPGeo_Admin.map, "click", function(e) {
 				$("#wpgeo_location").trigger({
@@ -57,7 +57,7 @@
 					lng    : e.latLng.lng()
 				});
 			});
-			
+
 			// Update map type
 			google.maps.event.addListener(WPGeo_Admin.map, "maptypeid_changed", function() {
 				var type = WPGeo_Admin.map.getMapTypeId();
@@ -80,7 +80,7 @@
 					mapType : type
 				});
 			});
-			
+
 			// Update zoom
 			google.maps.event.addListener(WPGeo_Admin.map, "zoom_changed", function() {
 				$("#wpgeo_location").trigger({
@@ -88,7 +88,7 @@
 					zoom : WPGeo_Admin.map.getZoom()
 				});
 			});
-			
+
 			// Update center
 			google.maps.event.addListener(WPGeo_Admin.map, "dragend", function() {
 				$("#wpgeo_location").trigger({
@@ -98,7 +98,7 @@
 					lng    : WPGeo_Admin.map.getCenter().lng(),
 				});
 			});
-			
+
 			// Update marker location after drag
 			google.maps.event.addListener(WPGeo_Admin.marker, "dragend", function(event) {
 				$("#wpgeo_location").trigger({
@@ -108,17 +108,17 @@
 					lng    : WPGeo_Admin.marker.getPosition().lng(),
 				});
 			});
-			
+
 			// Hide marker?
 			$("#wpgeo_location").bind("WPGeo_hideMarker", function(e){
 				WPGeo_Admin.marker.setVisible(false);
 			});
-			
+
 			// Move to center marker
 			$("#wpgeo_location").bind("WPGeo_centerLocation", function(e){
 				WPGeo_Admin.map.setCenter(WPGeo_Admin.marker.getPosition());
 			});
-			
+
 			// Search Location
 			$("#wpgeo_location").bind("WPGeo_searchLocation", function(e){
 				var geocoder = new google.maps.Geocoder();
@@ -135,7 +135,7 @@
 								type   : 'WPGeo_updateMarkerLatLng',
 								latLng : results[0].geometry.location,
 								lat    : results[0].geometry.location.lat(),
-								lng    : results[0].geometry.location.lng(),
+								lng    : results[0].geometry.location.lng()
 							});
 						} else {
 							alert(e.address + " not found");
@@ -143,10 +143,10 @@
 					});
 				}
 			});
-			
+
 			// Show/hide marker by default?
 			WPGeo_Admin.marker.setVisible(WPGeo_Admin.hideMarker);
-			
+
 			// Map ready, do other stuff if needed
 			$("#wpgeo_location").trigger("WPGeo_adminPostMapReady");
 		});

--- a/includes/wp-geo.php
+++ b/includes/wp-geo.php
@@ -5,11 +5,11 @@
  * The main WP Geo class - this is where it all happens.
  */
 class WPGeo {
-	
+
 	// Version Information
 	var $version    = '3.2.7.1';
 	var $db_version = 1;
-	
+
 	var $api;
 	var $admin;
 	var $markers;
@@ -17,22 +17,22 @@ class WPGeo {
 	var $maps;
 	var $maps2;
 	var $feeds;
-	
+
 	var $default_map_latitude  = '51.492526418807465';
 	var $default_map_longitude = '-0.15754222869873047';
-	
+
 	/**
 	 * Constructor
 	 */
 	function WPGeo() {
-		
+
 		// Version
 		$wp_geo_version = get_option( 'wp_geo_version' );
 		if ( empty( $wp_geo_version ) || version_compare( $wp_geo_version, $this->version, '<' ) ) {
 			//update_option( 'wp_geo_show_version_msg', 'Y' );
 			update_option( 'wp_geo_version', $this->version );
 		}
-		
+
 		// API
 		$wp_geo_options = get_option( 'wp_geo_options' );
 		if ( 'googlemapsv3' == $this->get_api_string() ) {
@@ -42,12 +42,12 @@ class WPGeo {
 			include_once( WPGEO_DIR . 'api/googlemapsv2/googlemapsv2.php' );
 			$this->api = new WPGeo_API_GoogleMapsV2();
 		}
-		
+
 		$this->maps    = array();
 		$this->maps2   = new WPGeo_Maps();
 		$this->markers = new WPGeo_Markers();
 		$this->feeds   = new WPGeo_Feeds();
-		
+
 		// Action Hooks
 		add_action( 'init', array( $this, 'init' ) );
 		add_action( 'init', array( $this, 'init_later' ), 10000 );
@@ -56,7 +56,7 @@ class WPGeo {
 		add_action( 'wp_footer', array( $this, 'wp_footer' ) );
 		add_action( 'admin_footer', array( $this, 'wp_footer' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		
+
 		// Filters
 		add_filter( 'the_content', array( $this, 'the_content' ) );
 		add_filter( 'get_the_excerpt', array( $this, 'get_the_excerpt' ) );
@@ -64,14 +64,14 @@ class WPGeo {
 		add_filter( 'posts_join', array( $this, 'posts_join' ) );
 		add_filter( 'posts_where', array( $this, 'posts_where' ) );
 		add_filter( 'option_wp_geo_options', array( $this, 'option_wp_geo_options' ) );
-		
+
 		// Admin
 		if ( is_admin() ) {
 			include_once( WPGEO_DIR . 'admin/admin.php' );
 			$this->admin = new WPGeo_Admin();
 		}
 	}
-	
+
 	/**
 	 * Filter 'wp_geo_options' value to ensure all defaults are set.
 	 *
@@ -81,7 +81,7 @@ class WPGeo {
 	function option_wp_geo_options( $option ) {
 		return wp_parse_args( $option, $this->default_option_values() );
 	}
-	
+
 	/**
 	 * Default Option Values
 	 */
@@ -89,12 +89,12 @@ class WPGeo {
 		return array(
 			'public_api'                    => 'googlemapsv2',
 			'admin_api'                     => 'googlemapsv2',
-			'google_api_key'                => '', 
-			'google_map_type'               => 'G_NORMAL_MAP', 
-			'show_post_map'                 => 'TOP', 
+			'google_api_key'                => '',
+			'google_map_type'               => 'G_NORMAL_MAP',
+			'show_post_map'                 => 'TOP',
 			'default_map_latitude'          => '51.492526418807465',
 			'default_map_longitude'         => '-0.15754222869873047',
-			'default_map_width'             => '100%', 
+			'default_map_width'             => '100%',
 			'default_map_height'            => '300px',
 			'default_map_zoom'              => '5',
 			'default_map_control'           => 'GLargeMapControl3D',
@@ -122,14 +122,14 @@ class WPGeo {
 			'add_geo_information_to_rss'    => 'Y'
 		);
 	}
-	
+
 	/**
 	 * Register Activation
 	 * Runs when the plugin is activated - creates options etc.
 	 */
 	function register_activation() {
 		$wpgeo = new WPGeo();
-		
+
 		$options = $this->default_option_values();
 		// @todo Rather than add_option() check values and use update?
 		add_option( 'wp_geo_options', $options );
@@ -142,11 +142,11 @@ class WPGeo {
 			}
 		}
 		update_option( 'wp_geo_options', $wp_geo_options );
-		
+
 		// Files
 		$wpgeo->markers->register_activation();
 	}
-	
+
 	/**
 	 * Is WP Geo Feed?
 	 * Detects whether this is a WP Geo feed.
@@ -161,7 +161,7 @@ class WPGeo {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Post Limits
 	 * Removes limit on WP Geo feed to show all posts.
@@ -171,7 +171,7 @@ class WPGeo {
 	 */
 	function post_limits( $limit ) {
 		global $wpgeo;
-		
+
 		if ( $wpgeo->is_wpgeo_feed() ) {
 			if ( isset( $_GET['limit'] ) && is_numeric( $_GET['limit'] ) ) {
 				return 'LIMIT 0, ' . $_GET['limit'];
@@ -179,7 +179,7 @@ class WPGeo {
 		}
 		return $limit;
 	}
-	
+
 	/**
 	 * Posts Join
 	 * Joins the post meta tables onto the results of the posts table.
@@ -189,13 +189,13 @@ class WPGeo {
 	 */
 	function posts_join( $join ) {
 		global $wpdb, $wpgeo;
-		
+
 		if ( $wpgeo->is_wpgeo_feed() ) {
 			$join .= " LEFT JOIN $wpdb->postmeta ON (" . $wpdb->posts . ".ID = $wpdb->postmeta.post_id)";
 		}
 		return $join;
 	}
-	
+
 	/**
 	 * Posts Where
 	 * Adds extra WHERE clause to the posts results to only include posts with longitude and latitude.
@@ -205,13 +205,13 @@ class WPGeo {
 	 */
 	function posts_where( $where ) {
 		global $wpdb, $wpgeo;
-		
+
 		if ( $wpgeo->is_wpgeo_feed() ) {
 			$where .= " AND ($wpdb->postmeta.meta_key = '" . WPGEO_LATITUDE_META . "' OR $wpdb->postmeta.meta_key = '" . WPGEO_LONGITUDE_META . "')";
 		}
 		return $where;
 	}
-	
+
 	/**
 	 * Check Google API Key
 	 * Check that a Google API Key has been entered.
@@ -220,7 +220,7 @@ class WPGeo {
 	 */
 	function checkGoogleAPIKey() {
 		global $wpgeo;
-		
+
 		$wp_geo_options = get_option( 'wp_geo_options' );
 		$api_key = $wpgeo->get_google_api_key();
 		if ( empty( $api_key ) || ! isset( $api_key ) ) {
@@ -228,7 +228,7 @@ class WPGeo {
 		}
 		return true;
 	}
-	
+
 	/**
 	 * Get Google API Key
 	 * Gets the Google API Key. Passes it through a filter so it can be overriden by another plugin.
@@ -239,7 +239,7 @@ class WPGeo {
 		$wp_geo_options = get_option( 'wp_geo_options' );
 		return apply_filters( 'wpgeo_google_api_key', $wp_geo_options['google_api_key'] );
 	}
-	
+
 	/**
 	 * Category Map
 	 * Outputs the HTML for a category map.
@@ -248,24 +248,24 @@ class WPGeo {
 	 */
 	function categoryMap( $args = null ) {
 		global $post;
-		
+
 		$posts = array();
 		while ( have_posts() ) {
 			the_post();
 			$posts[] = $post;
 		}
 		rewind_posts();
-		
+
 		$wp_geo_options = get_option( 'wp_geo_options' );
 		$showmap = false;
-		
+
 		// Extract args
 		$allowed_args = array(
 			'width'  => $wp_geo_options['default_map_width'],
 			'height' => $wp_geo_options['default_map_height']
 		);
 		$args = wp_parse_args( $args, $allowed_args );
-		
+
 		for ( $i = 0; $i < count( $posts ); $i++ ) {
 			$post = $posts[$i];
 			$coord = new WPGeo_Coord( get_post_meta( $post->ID, WPGEO_LATITUDE_META, true ), get_post_meta( $post->ID, WPGEO_LONGITUDE_META, true ) );
@@ -273,9 +273,9 @@ class WPGeo {
 				$showmap = true;
 			}
 		}
-		
+
 		if ( $showmap && ! is_feed() && $this->checkGoogleAPIKey() ) {
-		
+
 			$map = new WPGeo_Map( 'visible' );
 			echo $map->get_map_html( array(
 				'classes' => array( 'wp_geo_map' ),
@@ -284,10 +284,10 @@ class WPGeo {
 					'height' => $args['height']
 				)
 			) );
-			
+
 		}
 	}
-	
+
 	/**
 	 * Meta Tags
 	 * Outputs geo-related meta tags.
@@ -298,7 +298,7 @@ class WPGeo {
 			$coord = new WPGeo_Coord( get_post_meta( $post->ID, WPGEO_LATITUDE_META, true ), get_post_meta( $post->ID, WPGEO_LONGITUDE_META, true ) );
 			$title = get_post_meta( $post->ID, WPGEO_TITLE_META, true );
 			$nl = "\n";
-			
+
 			if ( $coord->is_valid_coord() ) {
 				echo '<meta name="geo.position" content="' . $coord->get_delimited( ';' ) . '" />' . $nl; // Geo-Tag: Latitude and longitude
 				//echo '<meta name="geo.region" content="DE-BY" />' . $nl;                      // Geo-Tag: Country code (ISO 3166-1) and regional code (ISO 3166-2)
@@ -310,7 +310,7 @@ class WPGeo {
 			}
 		}
 	}
-	
+
 	/**
 	 * Enqueue scripts and styles
 	 */
@@ -318,20 +318,20 @@ class WPGeo {
 		wp_register_style( 'wpgeo', WPGEO_URL . 'css/wp-geo.css' );
 		wp_enqueue_style( 'wpgeo' );
 	}
-	
+
 	/**
 	 * WP Head
 	 * Outputs HTML and JavaScript to the header.
 	 */
 	function wp_head() {
 		global $wpgeo, $post;
-		
+
 		$js_map_inits = '';
 		$js_marker_inits = '';
 		$wp_geo_options = get_option( 'wp_geo_options' );
-		
+
 		$this->meta_tags();
-		
+
 		$controltypes = array();
 		if ( $wp_geo_options['show_map_type_normal'] == 'Y' )
 			$controltypes[] = 'G_NORMAL_MAP';
@@ -341,11 +341,11 @@ class WPGeo {
 			$controltypes[] = 'G_HYBRID_MAP';
 		if ( $wp_geo_options['show_map_type_physical'] == 'Y' )
 			$controltypes[] = 'G_PHYSICAL_MAP';
-		
+
 		echo '
 			<script type="text/javascript">
 			//<![CDATA[
-			
+
 			// WP Geo default settings
 			var wpgeo_w = \'' . $wp_geo_options['default_map_width'] . '\';
 			var wpgeo_h = \'' . $wp_geo_options['default_map_height'] . '\';
@@ -355,11 +355,11 @@ class WPGeo {
 			var wpgeo_controltypes = \'' . implode(",", $controltypes) . '\';
 			var wpgeo_scale = \'' . $wp_geo_options['show_map_scale'] . '\';
 			var wpgeo_overview = \'' . $wp_geo_options['show_map_overview'] . '\';
-			
+
 			//]]>
 			</script>
 			';
-		
+
 		if ( $wpgeo->show_maps() || $wpgeo->widget_is_active() ) {
 			$posts = array();
 			while( have_posts() ) {
@@ -367,13 +367,13 @@ class WPGeo {
 				$posts[] = $post;
 			}
 			rewind_posts();
-			
+
 			$this->markers->wp_head();
-			
+
 			$wp_geo_options = get_option( 'wp_geo_options' );
 			$maptype = empty( $wp_geo_options['google_map_type'] ) ? 'G_NORMAL_MAP' : $wp_geo_options['google_map_type'];
 			$mapzoom = $wp_geo_options['default_map_zoom'];
-			
+
 			// Coords to show on map?
 			$coords = array();
 			for ( $i = 0; $i < count( $posts ); $i++ ) {
@@ -382,7 +382,7 @@ class WPGeo {
 				$title    = get_wpgeo_title( $post->ID );
 				$marker   = get_post_meta( $post->ID, WPGEO_MARKER_META, true );
 				$settings = get_post_meta( $post->ID, WPGEO_MAP_SETTINGS_META, true );
-				
+
 				$mymaptype = $maptype;
 				if ( isset( $settings['type'] ) && ! empty( $settings['type'] ) ) {
 					$mymaptype = $settings['type'];
@@ -391,7 +391,7 @@ class WPGeo {
 				if ( isset( $settings['zoom'] ) && is_numeric( $settings['zoom'] ) ) {
 					$mymapzoom = $settings['zoom'];
 				}
-				
+
 				if ( $coord->is_valid_coord() ) {
 					$push = array(
 						'id'    => $post->ID,
@@ -401,10 +401,10 @@ class WPGeo {
 						'post'  => $post
 					);
 					array_push( $coords, $push );
-					
+
 					// ----------- Start - Create maps for visible posts and pages -----------
 					$map = new WPGeo_Map( $post->ID );
-					
+
 					// Add point
 					$marker_large = empty( $marker ) ? 'large' : $marker;
 					$icon = apply_filters( 'wpgeo_marker_icon', $marker_large, $post, 'post' );
@@ -415,7 +415,7 @@ class WPGeo {
 					) );
 					$map->setMapZoom( $mymapzoom );
 					$map->setMapType( $mymaptype );
-					
+
 					if ( ! empty( $settings['centre'] ) ) {
 						$centre = explode( ',', $settings['centre'] );
 						if ( is_array( $centre ) && count( $centre ) == 2 ) {
@@ -426,7 +426,7 @@ class WPGeo {
 					} else {
 						$map->setMapCentre( $coord->latitude(), $coord->longitude() );
 					}
-					
+
 					if ( $wp_geo_options['show_map_type_physical'] == 'Y' )
 						$map->addMapType( 'G_PHYSICAL_MAP' );
 					if ( $wp_geo_options['show_map_type_normal'] == 'Y' )
@@ -435,26 +435,26 @@ class WPGeo {
 						$map->addMapType( 'G_SATELLITE_MAP' );
 					if ( $wp_geo_options['show_map_type_hybrid'] == 'Y' )
 						$map->addMapType( 'G_HYBRID_MAP' );
-					
+
 					if ( $wp_geo_options['show_map_scale'] == 'Y' )
 						$map->showMapScale( true );
 					if ( $wp_geo_options['show_map_overview'] == 'Y' )
 						$map->showMapOverview( true );
-					
+
 					$map->setMapControl( $wp_geo_options['default_map_control'] );
 					//$this->maps2->add_map( $map );
 					array_push( $this->maps, $map );
 					// ----------- End - Create maps for visible posts and pages -----------
 				}
 			}
-			
+
 			// Need a map?
 			if ( count( $coords ) > 0 ) {
-			
+
 				// ----------- Start - Create map for visible posts and pages -----------
 				$map = new WPGeo_Map( 'visible' );
 				$map->show_polyline = true;
-				
+
 				// Add points
 				for ( $j = 0; $j < count( $coords ); $j++ ) {
 					$marker_small = empty( $marker ) ? 'small' : $marker;
@@ -465,10 +465,10 @@ class WPGeo {
 						'link'  => $coords[$j]['link']
 					) );
 				}
-				
+
 				$map->setMapZoom( $mapzoom );
 				$map->setMapType( $maptype );
-				
+
 				if ( $wp_geo_options['show_map_type_physical'] == 'Y' )
 					$map->addMapType( 'G_PHYSICAL_MAP' );
 				if ( $wp_geo_options['show_map_type_normal'] == 'Y' )
@@ -477,37 +477,37 @@ class WPGeo {
 					$map->addMapType( 'G_SATELLITE_MAP' );
 				if ( $wp_geo_options['show_map_type_hybrid'] == 'Y' )
 					$map->addMapType( 'G_HYBRID_MAP' );
-				
+
 				if ( $wp_geo_options['show_map_scale'] == 'Y' )
 					$map->showMapScale( true );
 				if ( $wp_geo_options['show_map_overview'] == 'Y' )
 					$map->showMapOverview( true );
-					
+
 				$map->setMapControl( $wp_geo_options['default_map_control'] );
 				array_push( $this->maps, $map );
 				// ----------- End - Create map for visible posts and pages -----------
-				
+
 				$google_maps_api_key = $wpgeo->get_google_api_key();
 				$zoom = $wp_geo_options['default_map_zoom'];
-				
+
 				// Loop through maps to get Javascript
 				$js_map_writes = '';
 				foreach ( $this->maps as $map ) {
 					$js_map_writes .= $map->renderMapJS();
 				}
-						
+
 				// Script
 				$wpgeo->includeGoogleMapsJavaScriptAPI();
 				if ( 'googlemapsv3' == $this->get_api_string() ) {
-					
+
 					// Google Maps v3
 					$html_content = '
 						<script type="text/javascript">
 						//<![CDATA[
-						
+
 						var map = null; ' . $js_map_inits . '
 						var marker = null; ' . $js_marker_inits . '
-						
+
 						function init_wp_geo_map() {
 							' . $js_map_writes . '
 						}
@@ -515,15 +515,15 @@ class WPGeo {
 						//]]>
 						</script>';
 				} else {
-					
+
 					// Google Maps v2
 					$html_content = '
 						<script type="text/javascript">
 						//<![CDATA[
-						
+
 						var map = null; ' . $js_map_inits . '
 						var marker = null; ' . $js_marker_inits . '
-						
+
 						function init_wp_geo_map() {
 							if (GBrowserIsCompatible()) {
 								' . $js_map_writes . '
@@ -539,32 +539,32 @@ class WPGeo {
 						//]]>
 						</script>';
 				}
-				
+
 				echo $html_content;
 			}
 		}
 	}
-	
+
 	/**
 	 * Init
 	 * Runs actions on init if Google API Key exists.
 	 */
 	function init() {
-		
+
 		// Only show admin things if Google API Key valid
 		if ( $this->checkGoogleAPIKey() ) {
 			// Do an action for plugins to detect wether WP Geo is ready
 			do_action( 'wpgeo_init', $this );
 		}
 	}
-	
+
 	/**
 	 * Init Later
 	 * Called on WP action - runs after WordPress is ready.
 	 */
 	function init_later() {
 		$wp_geo_options = get_option( 'wp_geo_options' );
-		
+
 		// Support for custom post types
 		// Don't add support if on the WP settings page though
 		if ( ! is_admin() || ! isset( $_GET['page'] ) || ( isset( $_GET['page'] ) && $_GET['page'] != 'wp-geo' ) ) {
@@ -578,11 +578,11 @@ class WPGeo {
 				}
 			}
 		}
-		
+
 		// Add extra markers
 		$this->markers->add_extra_markers();
 	}
-	
+
 	/**
 	 * Include Google Maps JavaScript API
 	 * Queue JavaScripts required by WP Geo.
@@ -591,24 +591,24 @@ class WPGeo {
 	 */
 	function includeGoogleMapsJavaScriptAPI() {
 		global $wpgeo;
-		
+
 		$wp_geo_options = get_option( 'wp_geo_options' );
 		$http = is_ssl() ? 'https' : 'http';
-		
+
 		wp_register_script( 'wpgeo_tooltip', WPGEO_URL . 'js/tooltip.js', array( 'jquery' ), $this->version );
-		
+
 		if ( 'googlemapsv3' == $this->get_api_string() ) {
 			wp_register_script( 'wpgeo', WPGEO_URL . 'js/wp-geo.v3.js', array( 'jquery', 'wpgeo_tooltip' ), $this->version );
 		} else {
 			wp_register_script( 'wpgeo', WPGEO_URL . 'js/wp-geo.js', array( 'jquery', 'wpgeo_tooltip' ), $this->version );
 		}
 		wp_register_script( 'wpgeo_admin_post', WPGEO_URL . 'js/admin-post.js', array( 'jquery', 'wpgeo' ), $this->version );
-		
+
 		// Select API to use...
 		if ( ( $wpgeo->show_maps() || $wpgeo->widget_is_active() ) ) {
-		
+
 			if ( 'googlemapsv3' == $this->get_api_string() ) {
-				
+
 				// Google Maps v3
 				if ( $wpgeo->checkGoogleAPIKey() ) {
 					$googlemaps_js = add_query_arg( array(
@@ -616,10 +616,10 @@ class WPGeo {
 						'key'    => $wpgeo->get_google_api_key(),
 						'sensor' => 'false'
 					), $http . '://maps.googleapis.com/maps/api/js' );
-					
+
 					wp_register_script( 'googlemaps3', $googlemaps_js, false, $this->version );
 					wp_register_script( 'wpgeo_admin_post_googlemaps3', WPGEO_URL . 'api/googlemapsv3/js/admin-post.js', array( 'jquery', 'wpgeo_admin_post', 'googlemaps3' ), $this->version );
-					
+
 					wp_enqueue_script( 'wpgeo' );
 					wp_enqueue_script( 'googlemaps3' );
 					if ( is_admin() ) {
@@ -627,7 +627,7 @@ class WPGeo {
 					}
 				}
 			} else {
-				
+
 				// Google Maps v2
 				if ( $wpgeo->checkGoogleAPIKey() ) {
 					$googlemaps_js = add_query_arg( array(
@@ -636,10 +636,10 @@ class WPGeo {
 						'key'    => $wpgeo->get_google_api_key(),
 						'sensor' => 'false'
 					), $http . '://maps.google.com/maps?file=api' );
-					
+
 					wp_register_script( 'googlemaps2', $googlemaps_js, false, $this->version );
 					wp_register_script( 'wpgeo_admin_post_googlemaps2', WPGEO_URL . 'api/googlemapsv2/js/admin-post.js', array( 'jquery', 'wpgeo_admin_post', 'googlemaps2' ), $this->version );
-					
+
 					wp_enqueue_script( 'wpgeo' );
 					wp_enqueue_script( 'googlemaps2' );
 					if ( is_admin() ) {
@@ -649,7 +649,7 @@ class WPGeo {
 			}
 		}
 	}
-	
+
 	/**
 	 * Get Google Maps Locale
 	 * See http://code.google.com/apis/maps/faq.html#languagesupport for link to updated languages codes.
@@ -667,7 +667,7 @@ class WPGeo {
 			// WordPress locale is xx_XX, some codes are known
 			// by google with - in place of _ , so replace
 			$l = str_replace( '_', '-', $l );
-			
+
 			// Known Google codes known
 			$codes = array(
 				'en-AU',
@@ -677,36 +677,36 @@ class WPGeo {
 				'zh-CN',
 				'zh-TW'
 			);
-			
+
 			// Other codes known by googlemaps are 2 characters codes
 			if ( ! in_array( $l, $codes ) ) {
 				$l = substr( $l, 0, 2 );
 			}
 		}
-		
+
 		// Apply filter - why not ;)
 		$l = apply_filters( 'wp_geo_locale', $l );
-		
+
 		if ( ! empty( $l ) ) {
 			$l = $before . $l . $after;
 		}
 		return $l;
 	}
-	
+
 	/**
 	 * API String
 	 */
 	function api_string( $text, $context ) {
 		return apply_filters( 'wpgeo_api_string', $text, $text, $context );
 	}
-	
+
 	/**
 	 * Decode API String
 	 */
 	function decode_api_string( $text, $context ) {
 		return apply_filters( 'wpgeo_decode_api_string', $text, $text, $context );
 	}
-	
+
 	/**
 	 * Map Scripts Init
 	 * Output Javascripts to display maps.
@@ -720,11 +720,11 @@ class WPGeo {
 	 */
 	function mapScriptsInit( $latitude, $longitude, $zoom = 5, $panel_open = false, $hide_marker = false ) {
 		global $wpgeo, $post;
-		
+
 		$wp_geo_options = get_option( 'wp_geo_options' );
-		$maptype = empty( $wp_geo_options['google_map_type'] ) ? 'G_NORMAL_MAP' : $wp_geo_options['google_map_type'];	
+		$maptype = empty( $wp_geo_options['google_map_type'] ) ? 'G_NORMAL_MAP' : $wp_geo_options['google_map_type'];
 		$coord = new WPGeo_Coord( $latitude, $longitude );
-		
+
 		// Centre on London
 		if ( ! $coord->is_valid_coord() ) {
 			$coord       = new WPGeo_Coord( $wp_geo_options['default_map_latitude'], $wp_geo_options['default_map_longitude'] );
@@ -733,7 +733,7 @@ class WPGeo {
 			$hide_marker = true;
 		}
 		$map_center_coord = new WPGeo_Coord( $coord->latitude(), $coord->longitude() );
-		
+
 		if ( is_numeric( $post->ID ) && $post->ID > 0 ) {
 			$settings = get_post_meta( $post->ID, WPGEO_MAP_SETTINGS_META, true );
 			if ( isset( $settings['zoom'] ) && is_numeric( $settings['zoom'] ) ) {
@@ -752,39 +752,41 @@ class WPGeo {
 				}
 			}
 		}
-		
+
 		// Vars
 		$google_maps_api_key = $wpgeo->get_google_api_key();
 		$panel_open = ! $hide_marker || $panel_open ? '.removeClass("closed")' : '';
-		
+
+		$wpgeo_admin = array(
+			'api' => $this->get_api_string(),
+			'map_dom_id' => $this->admin->map->get_dom_id(),
+			'map' => null,
+			'marker' => null,
+			'zoom' => intval($zoom),
+			'mapCentreX' => $map_center_coord->latitude(),
+			'mapCentreY' => $map_center_coord->longitude(),
+			'latitude' => $coord->latitude(),
+			'longitude' => $coord->longitude(),
+			'hideMarker' => absint( $hide_marker ),
+		);
+
 		// Script
 		// @todo Maps API needs changing
 		$wpgeo->includeGoogleMapsJavaScriptAPI();
 		return '
 			<script type="text/javascript">
-			//<![CDATA[
-			var WPGeo_Admin = {
-				api        : "' . $this->get_api_string() . '",
-				map_dom_id : "' . $this->admin->map->get_dom_id() . '",
-				map        : null,
-				marker     : null,
-				zoom       : ' . $zoom . ',
-				mapCentreX : ' . $map_center_coord->latitude() . ',
-				mapCentreY : ' . $map_center_coord->longitude() . ',
-				mapType    : ' . $this->api_string( $maptype, 'maptype' ) . ',
-				latitude   : ' . $coord->latitude() . ',
-				longitude  : ' . $coord->longitude() . ',
-				hideMarker : ' . absint( $hide_marker ) . '
-			};
+			var WPGeo_Admin = '.json_encode($wpgeo_admin).';
+			WPGeo_Admin.mapType = '.$this->api_string( $maptype, "maptype" ).';
+
 			jQuery(document).ready(function($) {
 				$("#wpgeo_location")' . $panel_open . '.bind("WPGeo_adminPostMapReady", function(e){
 					' . apply_filters( 'wpgeo_map_js_preoverlays', '', 'WPGeo_Admin.map' ) . '
 				});
 			});
-			//]]>
-			</script>';
+			</script>
+			';
 	}
-	
+
 	/**
 	 * Get The Excerpt
 	 * Output Map placeholders on excerpts if set to automatically.
@@ -799,20 +801,24 @@ class WPGeo {
 		}
 		return $content;
 	}
-	
+
 	/**
 	 * Get API String
 	 */
 	function get_api_string( $str = '%s' ) {
 		$wp_geo_options = get_option( 'wp_geo_options' );
 		if ( is_admin() ) {
+			if ( empty($wp_geo_options['admin_api']) )
+				$wp_geo_options['admin_api'] = 'googlemapsv3';
 			$str = sprintf( $str, $wp_geo_options['admin_api'] );
 		} else {
+			if ( empty($wp_geo_options['public_api']) )
+				$wp_geo_options['public_api'] = 'googlemapsv3';
 			$str = sprintf( $str, $wp_geo_options['public_api'] );
 		}
 		return $str;
 	}
-	
+
 	/**
 	 * The Content
 	 * Output Map placeholders in the content area if set to automatically.
@@ -822,13 +828,13 @@ class WPGeo {
 	 */
 	function the_content( $content = '' ) {
 		global $wpgeo, $post, $wpdb;
-		
+
 		$new_content = '';
 		if ( $wpgeo->show_maps() && ! is_feed() ) {
 			$wp_geo_options = get_option( 'wp_geo_options' );
-			
+
 			$coord = new WPGeo_Coord( get_post_meta( $post->ID, WPGEO_LATITUDE_META, true ), get_post_meta( $post->ID, WPGEO_LONGITUDE_META, true ) );
-			
+
 			// Need a map?
 			if ( $coord->is_valid_coord() ) {
 				$map = new WPGeo_Map( $post->ID );
@@ -841,10 +847,10 @@ class WPGeo {
 				) );
 				$new_content = apply_filters( 'wpgeo_the_content_map', $new_content );
 			}
-			
+
 			// Add map to content
 			$show_post_map = apply_filters( 'wpgeo_show_post_map', $wp_geo_options['show_post_map'], $post->ID );
-			
+
 			// Show at top/bottom of post
 			if ( $show_post_map == 'TOP' ) {
 				$content = $new_content . $content;
@@ -854,7 +860,7 @@ class WPGeo {
 		}
 		return $content;
 	}
-	
+
 	/**
 	 * Widget Is Active?
 	 */
@@ -871,24 +877,24 @@ class WPGeo {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Show Maps
 	 * Checks the current page/scenario and wether maps should be shown.
 	 */
 	function show_maps() {
 		global $post, $post_ID, $pagenow;
-		
+
 		$wp_geo_options = get_option( 'wp_geo_options' );
-		
+
 		// Check if domain is correct
 		if ( ! wpgeo_check_domain() )
 			return false;
-		
+
 		// Widget active
 		// if ( is_active_widget( array( 'WPGeo_Widget', 'map_widget' ) ) )
 		//	return true;
-		
+
 		// Check settings
 		if ( is_home() && $wp_geo_options['show_maps_on_home'] == 'Y' )
 			return $this->show_maps_filter( true );
@@ -917,7 +923,7 @@ class WPGeo {
 		if ( is_feed() && $wp_geo_options['add_geo_information_to_rss'] == 'Y' )        return $this->show_maps_filter( true );
 		if ( is_post_type_archive() && post_type_supports( get_post_type(), 'wpgeo' ) && $wp_geo_options['show_maps_on_home'] == 'Y' )
 			return $this->show_maps_filter( true );
-		
+
 		// Activate maps in admin...
 		if ( is_admin() ) {
 			// If editing a post or page...
@@ -927,14 +933,14 @@ class WPGeo {
 			if ( $pagenow == 'post-new.php' || $pagenow == 'page-new.php' )
 				return $this->show_maps_filter( true );
 		}
-		
+
 		// Do Action
 		if ( $this->show_maps_external )
 			return $this->show_maps_filter( true );
-		
+
 		return $this->show_maps_filter( false );
 	}
-	
+
 	/**
 	 * Show Maps Filter
 	 * Allows show maps value to be overridden.
@@ -945,7 +951,7 @@ class WPGeo {
 	function show_maps_filter( $show_maps = false ) {
 		return apply_filters( 'wpgeo_show_maps', $show_maps );
 	}
-	
+
 	/**
 	 * Options Checkbox HTML
 	 *
@@ -960,7 +966,7 @@ class WPGeo {
 			$id = $name;
 		return '<input name="' . $name . '" type="checkbox" id="' . $id . '" value="' . $val . '" ' . checked( $val, $checked, false ) . ' ' . disabled( true, $disabled, false ) . '/>';
 	}
-	
+
 	/**
 	 * Select Map Control
 	 * Map control array or menu.
@@ -982,7 +988,7 @@ class WPGeo {
 			'GSmallZoomControl'   => __( 'Small zoom control (no panning controls)', 'wp-geo' ),
 			''                    => __( 'No pan/zoom controls', 'wp-geo' )
 		);
-		
+
 		// Menu?
 		if ( $return = 'menu' ) {
 			$menu = '';
@@ -992,10 +998,10 @@ class WPGeo {
 			$menu = '<select name="' . $args['name'] . '" id="' . $args['id'] . '">' . $menu. '</select>';
 			return $menu;
 		}
-		
+
 		return $map_type_array;
 	}
-	
+
 	/**
 	 * Select Map Zoom
 	 * Map zoom array or menu.
@@ -1012,37 +1018,37 @@ class WPGeo {
 			'name'     => 'default_map_zoom',
 			'id'       => 'default_map_zoom'
 		) );
-		
+
 		// Deprecated compatibility
-		if ( $args['return'] == null ) 
+		if ( $args['return'] == null )
 			$args['return'] = $return;
-		if ( $args['selected'] == null ) 
+		if ( $args['selected'] == null )
 			$args['selected'] = $selected;
-		
+
 		// Array
 		$map_type_array = array(
-			'0'  => '0 - ' . __( 'Zoomed Out', 'wp-geo' ), 
-			'1'  => '1', 
-			'2'  => '2', 
-			'3'  => '3', 
-			'4'  => '4', 
-			'5'  => '5', 
-			'6'  => '6', 
-			'7'  => '7', 
-			'8'  => '8', 
-			'9'  => '9', 
-			'10' => '10', 
-			'11' => '11', 
-			'12' => '12', 
-			'13' => '13', 
-			'14' => '14', 
-			'15' => '15', 
-			'16' => '16', 
-			'17' => '17', 
-			'18' => '18', 
-			'19' => '19 - ' . __( 'Zoomed In', 'wp-geo' ), 
+			'0'  => '0 - ' . __( 'Zoomed Out', 'wp-geo' ),
+			'1'  => '1',
+			'2'  => '2',
+			'3'  => '3',
+			'4'  => '4',
+			'5'  => '5',
+			'6'  => '6',
+			'7'  => '7',
+			'8'  => '8',
+			'9'  => '9',
+			'10' => '10',
+			'11' => '11',
+			'12' => '12',
+			'13' => '13',
+			'14' => '14',
+			'15' => '15',
+			'16' => '16',
+			'17' => '17',
+			'18' => '18',
+			'19' => '19 - ' . __( 'Zoomed In', 'wp-geo' ),
 		);
-		
+
 		// Menu?
 		if ( $return = 'menu' ) {
 			$menu = '';
@@ -1052,10 +1058,10 @@ class WPGeo {
 			$menu = '<select name="' . $args['name'] . '" id="' . $args['id'] . '">' . $menu. '</select>';
 			return $menu;
 		}
-		
+
 		return $map_type_array;
 	}
-	
+
 	/**
 	 * Google Map Types
 	 * Map type array or menu.
@@ -1072,21 +1078,21 @@ class WPGeo {
 			'name'     => 'google_map_type',
 			'id'       => 'google_map_type'
 		) );
-		
+
 		// Deprecated compatibility
-		if ( $args['return'] == null ) 
+		if ( $args['return'] == null )
 			$args['return'] = $return;
-		if ( $args['selected'] == null ) 
+		if ( $args['selected'] == null )
 			$args['selected'] = $selected;
-		
+
 		// Array
 		$map_type_array = array(
-			'G_NORMAL_MAP' 		=> __( 'Normal', 'wp-geo' ), 
-			'G_SATELLITE_MAP' 	=> __( 'Satellite (photographic map)', 'wp-geo' ), 
+			'G_NORMAL_MAP' 		=> __( 'Normal', 'wp-geo' ),
+			'G_SATELLITE_MAP' 	=> __( 'Satellite (photographic map)', 'wp-geo' ),
 			'G_HYBRID_MAP' 		=> __( 'Hybrid (photographic map with normal features)', 'wp-geo' ),
 			'G_PHYSICAL_MAP' 	=> __( 'Physical (terrain map)', 'wp-geo' )
 		);
-		
+
 		// Menu?
 		if ( $args['return'] = 'menu' ) {
 			$menu = '';
@@ -1096,10 +1102,10 @@ class WPGeo {
 			$menu = '<select name="' . $args['name'] . '" id="' . $args['id'] . '">' . $menu. '</select>';
 			return $menu;
 		}
-		
+
 		return $map_type_array;
 	}
-	
+
 	/**
 	 * Post Map Menu
 	 * Map position array or menu.
@@ -1114,11 +1120,11 @@ class WPGeo {
 			'id'   => 'show_post_map'
 		) );
 		$map_type_array = array(
-			'TOP'    => __( 'At top of post', 'wp-geo' ), 
-			'BOTTOM' => __( 'At bottom of post', 'wp-geo' ), 
+			'TOP'    => __( 'At top of post', 'wp-geo' ),
+			'BOTTOM' => __( 'At bottom of post', 'wp-geo' ),
 			'HIDE'   => __( 'Manually', 'wp-geo' )
 		);
-		
+
 		// Menu?
 		if ( $return = 'menu' ) {
 			$menu = '';
@@ -1128,10 +1134,10 @@ class WPGeo {
 			$menu = '<select name="' . $args['name'] . '" id="' . $args['id'] . '">' . $menu. '</select>';
 			return $menu;
 		}
-		
+
 		return $map_type_array;
 	}
-	
+
 	/**
 	 * Get WP Geo Posts
 	 *
@@ -1142,22 +1148,22 @@ class WPGeo {
 	 */
 	function get_wpgeo_posts( $args = null ) {
 		global $customFields;
-		
+
 		$default_args = array(
 			'numberposts' => 5
 		);
 		$arguments = wp_parse_args( $args, $default_args );
 		extract( $arguments, EXTR_SKIP );
-		
+
 		$customFields = "'" . WPGEO_LONGITUDE_META . "', '" . WPGEO_LATITUDE_META . "'";
-		
+
 		$custom_posts = new WP_Query();
 		add_filter( 'posts_join', array( $this, 'get_custom_field_posts_join' ) );
 		add_filter( 'posts_groupby', array( $this, 'get_custom_field_posts_group' ) );
 		$custom_posts->query( 'showposts=' . $numberposts );
 		remove_filter( 'posts_join', array( $this, 'get_custom_field_posts_join' ) );
 		remove_filter( 'posts_groupby', array( $this, 'get_custom_field_posts_group' ) );
-		
+
 		$points = array();
 		while ( $custom_posts->have_posts() ) {
 			$custom_posts->the_post();
@@ -1173,7 +1179,7 @@ class WPGeo {
 		}
 		return $points;
 	}
-	
+
 	/**
 	 * Get Custom Field Posts Join
 	 * Join custom fields on to results.
@@ -1187,7 +1193,7 @@ class WPGeo {
 		global $wpdb, $customFields;
 		return $join . " JOIN $wpdb->postmeta postmeta ON (postmeta.post_id = $wpdb->posts.ID and postmeta.meta_key in ($customFields))";
 	}
-	
+
 	/**
 	 * Get Custom Field Posts Group
 	 * Group by post id.
@@ -1200,14 +1206,14 @@ class WPGeo {
 		$group .= " $wpdb->posts.ID ";
 		return $group;
 	}
-	
+
 	/**
 	 * WP Footer
 	 */
 	function wp_footer() {
 		do_action( $this->get_api_string( 'wpgeo_api_%s_js' ), $this->maps2->maps );
 	}
-	
+
 }
 
 ?>


### PR DESCRIPTION
In /api/googleapiv3/js/admin-post.js you had a comma at the end of an object which would error out in IE

I've moved WPGeo_Admin JS definitions into a PHP array and displayed with json_encode(). This fixes an error when a user hasn't let lat or long settings in admin - it was erroring out.
