### PR TITLE
Only get_options if we need to

### DIFF
--- a/includes/wp-geo.php
+++ b/includes/wp-geo.php
@@ -5,11 +5,11 @@
  * The main WP Geo class - this is where it all happens.
  */
 class WPGeo {
-	
+
 	// Version Information
 	var $version    = '3.3.8';
 	var $db_version = 1;
-	
+
 	var $api;
 	var $admin;
 	var $wpgeo_query;
@@ -17,15 +17,15 @@ class WPGeo {
 	var $show_maps_external = false;
 	var $maps;
 	var $feeds;
-	
+
 	var $default_map_latitude  = '51.492526418807465';
 	var $default_map_longitude = '-0.15754222869873047';
-	
+
 	/**
 	 * Constructor
 	 */
 	function WPGeo() {
-		
+
 		// API
 		$wp_geo_options = get_option( 'wp_geo_options' );
 		if ( 'googlemapsv3' == $this->get_api_string() ) {
@@ -42,7 +42,7 @@ class WPGeo {
 		$this->maps        = new WPGeo_Maps();
 		$this->markers     = new WPGeo_Markers();
 		$this->feeds       = new WPGeo_Feeds();
-		
+
 		// Action Hooks
 		add_action( 'plugins_loaded', array( $this, '_maybe_upgrade' ), 5 );
 		add_action( 'init', array( $this, 'init' ) );
@@ -52,7 +52,7 @@ class WPGeo {
 		add_action( 'wp_head', array( $this, 'wp_head' ) );
 		add_action( 'wp_footer', array( $this, 'wp_footer' ) );
 		add_action( 'admin_footer', array( $this, 'wp_footer' ) );
-		
+
 		// Filters
 		add_filter( 'the_content', array( $this, 'the_content' ) );
 		add_filter( 'get_the_excerpt', array( $this, 'get_the_excerpt' ) );
@@ -65,7 +65,7 @@ class WPGeo {
 			$this->admin = new WPGeo_Admin();
 		}
 	}
-	
+
 	/**
 	 * Filter 'wp_geo_options' value to ensure all defaults are set.
 	 *
@@ -75,7 +75,7 @@ class WPGeo {
 	function option_wp_geo_options( $option ) {
 		return wp_parse_args( $option, $this->default_option_values() );
 	}
-	
+
 	/**
 	 * Default Option Values
 	 */
@@ -83,12 +83,12 @@ class WPGeo {
 		return array(
 			'public_api'                    => 'googlemapsv3',
 			'admin_api'                     => 'googlemapsv3',
-			'google_api_key'                => '', 
-			'google_map_type'               => 'G_NORMAL_MAP', 
-			'show_post_map'                 => 'TOP', 
+			'google_api_key'                => '',
+			'google_map_type'               => 'G_NORMAL_MAP',
+			'show_post_map'                 => 'TOP',
 			'default_map_latitude'          => '51.492526418807465',
 			'default_map_longitude'         => '-0.15754222869873047',
-			'default_map_width'             => '100%', 
+			'default_map_width'             => '100%',
 			'default_map_height'            => '300px',
 			'default_map_zoom'              => '5',
 			'default_map_control'           => 'GLargeMapControl3D',
@@ -118,7 +118,7 @@ class WPGeo {
 			'add_geo_information_to_rss'    => 'Y'
 		);
 	}
-	
+
 	/**
 	 * Maybe Upgrade
 	 * Checks on each admin page load wether the plugin upgrade routine should
@@ -129,18 +129,18 @@ class WPGeo {
 		if ( empty( $wp_geo_version ) || version_compare( $wp_geo_version, $this->version, '<' ) ) {
 			update_option( 'wp_geo_show_version_msg', 'Y' );
 			update_option( 'wp_geo_version', $this->version );
-			
+
 			// Update Options
 			$default_options = $this->default_option_values();
 			$options = get_option( 'wp_geo_options', $default_options );
 			$options = wp_parse_args( $options, $default_options );
 			update_option( 'wp_geo_options', $options );
-			
+
 			// Files
 			$this->markers->register_activation();
 		}
 	}
-	
+
 	/**
 	 * Is WP Geo Feed?
 	 * Detects whether this is a WP Geo feed.
@@ -192,24 +192,24 @@ class WPGeo {
 	 */
 	function categoryMap( $args = null ) {
 		global $post;
-		
+
 		$posts = array();
 		while ( have_posts() ) {
 			the_post();
 			$posts[] = $post;
 		}
 		rewind_posts();
-		
+
 		$wp_geo_options = get_option( 'wp_geo_options' );
 		$showmap = false;
-		
+
 		// Extract args
 		$allowed_args = array(
 			'width'  => $wp_geo_options['default_map_width'],
 			'height' => $wp_geo_options['default_map_height']
 		);
 		$args = wp_parse_args( $args, $allowed_args );
-		
+
 		for ( $i = 0; $i < count( $posts ); $i++ ) {
 			$post = $posts[$i];
 			$coord = get_wpgeo_post_coord( $post->ID );
@@ -217,9 +217,9 @@ class WPGeo {
 				$showmap = true;
 			}
 		}
-		
+
 		if ( $showmap && ! is_feed() && $this->checkGoogleAPIKey() ) {
-		
+
 			$map = new WPGeo_Map( 'visible' );
 			echo $map->get_map_html( array(
 				'classes' => array( 'wp_geo_map' ),
@@ -228,7 +228,7 @@ class WPGeo {
 					'height' => $args['height']
 				)
 			) );
-			
+
 		}
 	}
 
@@ -309,7 +309,7 @@ class WPGeo {
 		}
 		return $controltypes;
 	}
-	
+
 	/**
 	 * Post Types Supports
 	 *
@@ -326,32 +326,31 @@ class WPGeo {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Init
 	 * Runs actions on init if Google API Key exists.
 	 */
 	function init() {
-		
+
 		// Only show admin things if Google API Key valid
 		if ( $this->checkGoogleAPIKey() ) {
 			// Do an action for plugins to detect wether WP Geo is ready
 			do_action( 'wpgeo_init', $this );
 		}
 	}
-	
+
 	/**
 	 * Init Later
 	 * Called on WP action - runs after WordPress is ready.
 	 */
 	function init_later() {
-		$wp_geo_options = get_option( 'wp_geo_options' );
-		
 		// Support for custom post types
 		// Don't add support if on the WP settings page though
 		if ( ! is_admin() || ! isset( $_GET['page'] ) || ( isset( $_GET['page'] ) && $_GET['page'] != 'wp-geo' ) ) {
 			if ( function_exists( 'get_post_types' ) && function_exists( 'add_post_type_support' ) && isset( $wp_geo_options['show_maps_on_customposttypes'] ) ) {
 				$post_types = get_post_types();
+				$wp_geo_options = get_option( 'wp_geo_options' );
 				foreach ( $post_types as $post_type ) {
 					$post_type_object = get_post_type_object( $post_type );
 					if ( $post_type_object->show_ui && array_key_exists( $post_type, $wp_geo_options['show_maps_on_customposttypes'] ) && $wp_geo_options['show_maps_on_customposttypes'][$post_type] == 'Y' ) {
@@ -360,7 +359,7 @@ class WPGeo {
 				}
 			}
 		}
-		
+
 		// Add extra markers
 		$this->markers->add_extra_markers();
 	}
@@ -437,7 +436,7 @@ class WPGeo {
 			// WordPress locale is xx_XX, some codes are known
 			// by google with - in place of _ , so replace
 			$l = str_replace( '_', '-', $l );
-			
+
 			// Known Google codes known
 			$codes = array(
 				'en-AU',
@@ -447,36 +446,36 @@ class WPGeo {
 				'zh-CN',
 				'zh-TW'
 			);
-			
+
 			// Other codes known by googlemaps are 2 characters codes
 			if ( ! in_array( $l, $codes ) ) {
 				$l = substr( $l, 0, 2 );
 			}
 		}
-		
+
 		// Apply filter - why not ;)
 		$l = apply_filters( 'wp_geo_locale', $l );
-		
+
 		if ( ! empty( $l ) ) {
 			$l = $before . $l . $after;
 		}
 		return $l;
 	}
-	
+
 	/**
 	 * API String
 	 */
 	function api_string( $text, $context ) {
 		return apply_filters( 'wpgeo_api_string', $text, $text, $context );
 	}
-	
+
 	/**
 	 * Decode API String
 	 */
 	function decode_api_string( $text, $context ) {
 		return apply_filters( 'wpgeo_decode_api_string', $text, $text, $context );
 	}
-	
+
 	/**
 	 * Map Scripts Init
 	 * Output Javascripts to display maps.
@@ -489,10 +488,10 @@ class WPGeo {
 	 */
 	function mapScriptsInit( $coord, $zoom = 5, $panel_open = false, $hide_marker = false ) {
 		global $wpgeo, $post;
-		
+
 		$wp_geo_options = get_option( 'wp_geo_options' );
 		$maptype = empty( $wp_geo_options['google_map_type'] ) ? 'G_NORMAL_MAP' : $wp_geo_options['google_map_type'];
-		
+
 		// Centre on London
 		if ( ! $coord->is_valid_coord() ) {
 			$coord       = new WPGeo_Coord( $wp_geo_options['default_map_latitude'], $wp_geo_options['default_map_longitude'] );
@@ -501,7 +500,7 @@ class WPGeo {
 			$hide_marker = true;
 		}
 		$map_center_coord = new WPGeo_Coord( $coord->latitude(), $coord->longitude() );
-		
+
 		if ( isset( $post ) && is_numeric( $post->ID ) && $post->ID > 0 ) {
 			$settings = WPGeo::get_post_map_settings( $post->ID );
 			if ( isset( $settings['zoom'] ) && is_numeric( $settings['zoom'] ) ) {
@@ -520,10 +519,10 @@ class WPGeo {
 				}
 			}
 		}
-		
+
 		// Vars
 		$panel_open = ! $hide_marker || $panel_open ? '.removeClass("closed")' : '';
-		
+
 		$wpgeo_admin_vars = array(
 			'api'        => $this->get_api_string(),
 			'map_dom_id' => $this->admin->map->get_dom_id(),
@@ -536,14 +535,14 @@ class WPGeo {
 			'longitude'  => $coord->longitude(),
 			'hideMarker' => absint( $hide_marker )
 		);
-		
+
 		// Script
 		// @todo Maps API needs changing
 		return '
 			<script type="text/javascript">
 			var WPGeo_Admin = ' . json_encode( $wpgeo_admin_vars ) . ';
 			WPGeo_Admin.mapType = ' . $this->api_string( $maptype, 'maptype' ) . ';
-			
+
 			jQuery(document).ready(function($) {
 				$("#wpgeo_location")' . $panel_open . '.bind("WPGeo_adminPostMapReady", function(e){
 					' . apply_filters( 'wpgeo_map_js_preoverlays', '', 'WPGeo_Admin.map' ) . '
@@ -552,7 +551,7 @@ class WPGeo {
 			</script>
 			';
 	}
-	
+
 	/**
 	 * Get The Excerpt
 	 * Output Map placeholders on excerpts if set to automatically.
@@ -603,7 +602,7 @@ class WPGeo {
 		}
 		return $str;
 	}
-	
+
 	/**
 	 * The Content
 	 * Output Map placeholders in the content area if set to automatically.
@@ -613,7 +612,7 @@ class WPGeo {
 	 */
 	function the_content( $content = '' ) {
 		global $wpgeo, $post, $wpdb;
-		
+
 		$new_content = '';
 		if ( $wpgeo->show_maps() && ! is_feed() ) {
 			$wp_geo_options = get_option( 'wp_geo_options' );
@@ -648,7 +647,7 @@ class WPGeo {
 				) );
 				$map->setMapZoom( $mymapzoom );
 				$map->setMapType( $mymaptype );
-	
+
 				if ( ! empty( $settings['centre'] ) ) {
 					$centre = explode( ',', $settings['centre'] );
 					if ( is_array( $centre ) && count( $centre ) == 2 ) {
@@ -674,7 +673,7 @@ class WPGeo {
 				if ( $wp_geo_options['show_streetview_control'] == 'Y' ) {
 					$map->show_streetview_control( true );
 				}
-				
+
 				$map->setMapControl( $wp_geo_options['default_map_control'] );
 
 				$wpgeo->maps->add_map( $map );
@@ -688,10 +687,10 @@ class WPGeo {
 				) );
 				$new_content = apply_filters( 'wpgeo_the_content_map', $new_content );
 			}
-			
+
 			// Add map to content
 			$show_post_map = apply_filters( 'wpgeo_show_post_map', $wp_geo_options['show_post_map'], $post->ID );
-			
+
 			// Show at top/bottom of post
 			if ( $show_post_map == 'TOP' ) {
 				$content = $new_content . $content;
@@ -701,7 +700,7 @@ class WPGeo {
 		}
 		return $content;
 	}
-	
+
 	/**
 	 * Widget Is Active?
 	 */
@@ -718,26 +717,26 @@ class WPGeo {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Show Maps
 	 * Checks the current page/scenario and wether maps should be shown.
 	 */
 	function show_maps() {
 		global $wpgeo, $post, $post_ID, $pagenow;
-		
+
 		$wp_geo_options = get_option( 'wp_geo_options' );
-		
+
 		// Check if domain is correct
 		if ( ! wpgeo_check_domain() ) {
 			return false;
 		}
-		
+
 		// Widget active
 		// if ( is_active_widget( array( 'WPGeo_Widget', 'map_widget' ) ) ) {
 		//	return true;
 		// }
-		
+
 		// Check settings
 		if ( is_home() && $wp_geo_options['show_maps_on_home'] == 'Y' ) {
 			return $this->show_maps_filter( true );
@@ -779,7 +778,7 @@ class WPGeo {
 		if ( is_post_type_archive() && $wpgeo->post_type_supports( get_post_type() ) && $wp_geo_options['show_maps_on_home'] == 'Y' ) {
 			return $this->show_maps_filter( true );
 		}
-		
+
 		// Activate maps in admin...
 		if ( is_admin() ) {
 			// If editing a post or page...
@@ -791,15 +790,15 @@ class WPGeo {
 				return $this->show_maps_filter( true );
 			}
 		}
-		
+
 		// Do Action
 		if ( $this->show_maps_external ) {
 			return $this->show_maps_filter( true );
 		}
-		
+
 		return $this->show_maps_filter( false );
 	}
-	
+
 	/**
 	 * Show Maps Filter
 	 * Allows show maps value to be overridden.
@@ -810,7 +809,7 @@ class WPGeo {
 	function show_maps_filter( $show_maps = false ) {
 		return apply_filters( 'wpgeo_show_maps', $show_maps );
 	}
-	
+
 	/**
 	 * Options Checkbox HTML
 	 *
@@ -925,22 +924,22 @@ class WPGeo {
 	 */
 	function get_wpgeo_posts( $args = null ) {
 		global $customFields;
-		
+
 		$default_args = array(
 			'numberposts' => 5
 		);
 		$arguments = wp_parse_args( $args, $default_args );
 		extract( $arguments, EXTR_SKIP );
-		
+
 		$customFields = "'" . WPGEO_LONGITUDE_META . "', '" . WPGEO_LATITUDE_META . "'";
-		
+
 		$custom_posts = new WP_Query();
 		add_filter( 'posts_join', array( $this->wpgeo_query, 'get_custom_field_posts_join' ) );
 		add_filter( 'posts_groupby', array( $this->wpgeo_query, 'get_custom_field_posts_group' ) );
 		$custom_posts->query( 'showposts=' . $numberposts );
 		remove_filter( 'posts_join', array( $this->wpgeo_query, 'get_custom_field_posts_join' ) );
 		remove_filter( 'posts_groupby', array( $this->wpgeo_query, 'get_custom_field_posts_group' ) );
-		
+
 		$points = array();
 		while ( $custom_posts->have_posts() ) {
 			$custom_posts->the_post();
@@ -963,5 +962,5 @@ class WPGeo {
 	function wp_footer() {
 		do_action( $this->get_api_string( 'wpgeo_api_%s_js' ), $this->maps->maps );
 	}
-	
+
 }


### PR DESCRIPTION
As per [my support message](http://wordpress.org/support/topic/patch-only-get-options-when-required-on-init?replies=1), you have a get_option check that is called when it isn't needed.

Line 348 of this commit - sorry for all the line ending trimmings, my editor does it automatically on save.