### PR TITLE
Get rid of SensortNotRequired JS warning.

### DIFF
--- a/api/googlemapsv3/googlemapsv3.php
+++ b/api/googlemapsv3/googlemapsv3.php
@@ -60,7 +60,6 @@ class WPGeo_API_GoogleMapsV3 extends WPGeo_API {
 		global $wpgeo;
 		$googlemaps_js_args = array(
 			'language' => $wpgeo->get_googlemaps_locale(),
-			'sensor'   => 'false'
 		);
 		$api_key = $wpgeo->get_google_api_key();
 		if ( ! empty( $api_key ) ) {


### PR DESCRIPTION
Get rid of JS warning that sensor param is no longer required:
https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required