### PR TITLE
create_function() is deprecated

### DIFF
--- a/widgets/category-map.php
+++ b/widgets/category-map.php
@@ -97,4 +97,6 @@ class WPGeo_Category_Map_Widget extends WPGeo_Widget {
 }
 
 // Widget Hook
-add_action( 'widgets_init', create_function( '', 'return register_widget( "WPGeo_Category_Map_Widget" );' ) );
+add_action( 'widgets_init', function() {
+	return register_widget( "WPGeo_Category_Map_Widget" );
+});

--- a/widgets/contextual-map.php
+++ b/widgets/contextual-map.php
@@ -84,4 +84,6 @@ class WPGeo_Contextual_Map_Widget extends WPGeo_Widget {
 }
 
 // Widget Hook
-add_action( 'widgets_init', create_function( '', 'return register_widget( "WPGeo_Contextual_Map_Widget" );' ) );
+add_action( 'widgets_init', function() {
+	return register_widget( "WPGeo_Contextual_Map_Widget" );
+});

--- a/widgets/recent-locations.php
+++ b/widgets/recent-locations.php
@@ -134,4 +134,6 @@ class WPGeo_Recent_Locations_Widget extends WPGeo_Widget {
 }
 
 // Widget Hook
-add_action( 'widgets_init', create_function( '', 'return register_widget( "WPGeo_Recent_Locations_Widget" );' ) );
+add_action( 'widgets_init', function() {
+	return register_widget( "WPGeo_Recent_Locations_Widget" );
+});


### PR DESCRIPTION
[create_function()](https://www.php.net/create_function) has been deprecated since PHP7.2 and results in huge error blocks on the post edit page in PHP7.4.